### PR TITLE
Fix: Prevent UI from getting stuck on initial loading screen

### DIFF
--- a/lib/src/features/a_ideation/presentation/jam_lab_screen.dart
+++ b/lib/src/features/a_ideation/presentation/jam_lab_screen.dart
@@ -81,10 +81,12 @@ class _JamLabScreenState extends ConsumerState<JamLabScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('🧪 Jam Lab'),
-        backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
+    return DefaultTabController(
+      length: 4,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('🧪 Jam Lab'),
+          backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
         bottom: TabBar(
           onTap: (index) => setState(() => _selectedTabIndex = index),
           tabs: const [
@@ -93,16 +95,17 @@ class _JamLabScreenState extends ConsumerState<JamLabScreen> {
             Tab(text: '🎯 Insights'),
             Tab(text: '👨‍🔬 Researchers'),
           ],
+          ),
         ),
-      ),
-      body: IndexedStack(
+        body: IndexedStack(
         index: _selectedTabIndex,
         children: [
           _buildExperimentsTab(),
           _buildResearchTab(),
           _buildInsightsTab(),
           _buildResearchersTab(),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/features/b_authentication/data/mock_auth_repository.dart
+++ b/lib/src/features/b_authentication/data/mock_auth_repository.dart
@@ -20,6 +20,10 @@ class MockAuthRepository implements AuthRepository {
   @override
   Stream<User?> get authStateChanges {
     _authStateController ??= StreamController<User?>.broadcast();
+    // If no user is logged in, sign in anonymously.
+    if (_currentUser == null) {
+      signInAnonymously();
+    }
     return _authStateController!.stream;
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1168,26 +1168,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.11"
   timing:
     dependency: transitive
     description:
@@ -1280,10 +1280,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/test/features/b_authentication/auth_wrapper_test.dart
+++ b/test/features/b_authentication/auth_wrapper_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:project_jambam/src/features/b_authentication/presentation/auth_wrapper.dart';
+import 'package:project_jambam/src/features/b_authentication/presentation/login_screen.dart';
+import 'package:project_jambam/src/features/a_ideation/presentation/main_navigation_screen.dart';
+
+void main() {
+  testWidgets('AuthWrapper shows LoginScreen or MainNavigationScreen initially', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: AuthWrapper(),
+        ),
+      ),
+    );
+
+    // Wait for the initial state to settle.
+    // The mock auth repository now signs in an anonymous user by default.
+    // So, we expect to see the MainNavigationScreen.
+    await tester.pumpAndSettle();
+
+    // Verify that either LoginScreen or MainNavigationScreen is present.
+    // And that the loading indicator is not present.
+    final loginScreenFinder = find.byType(LoginScreen);
+    final mainNavigationScreenFinder = find.byType(MainNavigationScreen);
+    final loadingIndicatorFinder = find.byType(CircularProgressIndicator);
+
+    expect(
+        (loginScreenFinder.evaluate().isNotEmpty || mainNavigationScreenFinder.evaluate().isNotEmpty),
+        isTrue,
+        reason: 'Expected to find LoginScreen or MainNavigationScreen, but found neither.');
+    expect(loadingIndicatorFinder, findsNothing,
+        reason: 'Expected not to find loading indicator, but it was present.');
+  });
+}


### PR DESCRIPTION
The AuthWrapper was getting stuck on the loading screen because the MockAuthRepository wasn't emitting an initial authentication state.

This commit modifies the MockAuthRepository to automatically sign in an anonymous user if no user is currently logged in when the authStateChanges stream is first accessed. This ensures that the currentUserProvider emits an initial value, allowing the AuthWrapper to navigate to the appropriate screen (LoginScreen or MainNavigationScreen).

A widget test has been added to verify that the AuthWrapper no longer gets stuck on the loading screen. During testing, a separate issue related to a missing TabController in JamLabScreen was identified and fixed.