### PR TITLE
feat: Add legal pages (Privacy, Terms, Impressum)

### DIFF
--- a/web-portal/tech-radar/src/App.tsx
+++ b/web-portal/tech-radar/src/App.tsx
@@ -23,6 +23,9 @@ import RoadmapPage from './pages/RoadmapPage';
 import TeamPage from './pages/TeamPage'; // Import TeamPage
 import VisionMissionPage from './pages/VisionMissionPage'; // Import VisionMissionPage
 import FundingWorthinessPage from './pages/FundingWorthinessPage'; // Import FundingWorthinessPage
+import PrivacyPolicy from './pages/legal/PrivacyPolicy';
+import TermsOfService from './pages/legal/TermsOfService';
+import Impressum from './pages/legal/Impressum';
 import ThemeBackground from './components/ThemeBackground';
 import './App.css';
 
@@ -63,9 +66,9 @@ function App() {
                     {/* Placeholder routes for footer links */}
                     <Route path="/careers" element={<PlaceholderPage title="Careers" />} />
                     <Route path="/contact" element={<PlaceholderPage title="Contact Us" />} />
-                    <Route path="/imprint" element={<PlaceholderPage title="Imprint" />} />
-                    <Route path="/privacy" element={<PlaceholderPage title="Privacy Policy" />} />
-                    <Route path="/terms" element={<PlaceholderPage title="Terms of Service" />} />
+                    <Route path="/impressum" element={<Impressum />} />
+                    <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+                    <Route path="/terms-of-service" element={<TermsOfService />} />
                     <Route element={<ProtectedRoute />}>
                       <Route path="/tech-radar" element={<TechRadarPage />} />
                       <Route path="/profile" element={<ProfilePage />} />

--- a/web-portal/tech-radar/src/components/layout/Footer.tsx
+++ b/web-portal/tech-radar/src/components/layout/Footer.tsx
@@ -33,9 +33,9 @@ const Footer: React.FC = () => {
 
   // Define legal links (ensure these routes exist or create placeholder pages)
   const legalLinks = [
-    { to: '/imprint', text: t('footer.legal.imprint', 'Imprint') },
-    { to: '/privacy', text: t('footer.legal.privacy', 'Privacy Policy') },
-    { to: '/terms', text: t('footer.legal.terms', 'Terms of Service') },
+    { to: '/impressum', text: t('footer.legal.imprint', 'Imprint') },
+    { to: '/privacy-policy', text: t('footer.legal.privacy', 'Privacy Policy') },
+    { to: '/terms-of-service', text: t('footer.legal.terms', 'Terms of Service') },
   ];
 
   return (

--- a/web-portal/tech-radar/src/pages/legal/Impressum.tsx
+++ b/web-portal/tech-radar/src/pages/legal/Impressum.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+const Impressum: React.FC = () => {
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif', lineHeight: '1.6' }}>
+      <h1>Impressum</h1>
+
+      <h2>Angaben gemäß § 5 TMG</h2>
+      <p>
+        [Max Mustermann oder Firmenname]<br />
+        [Musterstraße 1]<br />
+        [12345 Musterstadt]
+      </p>
+
+      <h2>Kontakt</h2>
+      <p>
+        Telefon: [Ihre Telefonnummer (optional)]<br />
+        E-Mail: [Ihre E-Mail-Adresse]
+      </p>
+
+      <h2>Vertreten durch:</h2>
+      <p>
+        [Name des Vertretungsberechtigten, falls zutreffend, z.B. Geschäftsführer bei GmbH]
+      </p>
+
+      <h2>Registereintrag (falls vorhanden):</h2>
+      <p>
+        Eintragung im [Registergericht, z.B. Handelsregister, Vereinsregister, Partnerschaftsregister]<br />
+        Registernummer: [Ihre Registernummer]
+      </p>
+
+      <h2>Umsatzsteuer-ID (falls vorhanden):</h2>
+      <p>
+        Umsatzsteuer-Identifikationsnummer gemäß §27 a Umsatzsteuergesetz:<br />
+        DE[Ihre Umsatzsteuer-ID]
+      </p>
+
+      <h2>Wirtschafts-ID (falls vorhanden):</h2>
+      <p>
+        Wirtschafts-Identifikationsnummer gemäß §139c Abgabenordnung:<br />
+        [Ihre Wirtschafts-ID]
+      </p>
+
+      <h2>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:</h2>
+      <p>
+        [Max Mustermann oder Name des Verantwortlichen]<br />
+        [Anschrift des Verantwortlichen, falls abweichend von oben]
+      </p>
+
+      <h2>EU-Streitschlichtung</h2>
+      <p>
+        Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit: <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener noreferrer">https://ec.europa.eu/consumers/odr</a>.<br />
+        Unsere E-Mail-Adresse finden Sie oben im Impressum.
+      </p>
+
+      <h2>Verbraucher­streit­beilegung/Universal­schlichtungs­stelle</h2>
+      <p>
+        Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.
+      </p>
+
+      <h3>Haftung für Inhalte</h3>
+      <p>
+        Als Diensteanbieter sind wir gemäß § 7 Abs.1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen.
+      </p>
+      <p>
+        Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.
+      </p>
+
+      <h3>Haftung für Links</h3>
+      <p>
+        Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar.
+      </p>
+      <p>
+        Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links umgehend entfernen.
+      </p>
+
+      <h3>Urheberrecht</h3>
+      <p>
+        Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechtes bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet.
+      </p>
+      <p>
+        Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte Dritter beachtet. Insbesondere werden Inhalte Dritter als solche gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.
+      </p>
+
+      <p>Quelle: <a href="https://www.e-recht24.de">e-recht24.de</a></p>
+    </div>
+  );
+};
+
+export default Impressum;

--- a/web-portal/tech-radar/src/pages/legal/PrivacyPolicy.tsx
+++ b/web-portal/tech-radar/src/pages/legal/PrivacyPolicy.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+
+const PrivacyPolicy: React.FC = () => {
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif', lineHeight: '1.6' }}>
+      <h1>Privacy Policy</h1>
+      <p>Last updated: [Date]</p>
+
+      <h2>1. Introduction</h2>
+      <p>
+        Welcome to [Your Company/Website Name] ("us", "we", or "our"). We are committed to protecting your personal information and your right to privacy. If you have any questions or concerns about our policy, or our practices with regards to your personal information, please contact us at [Your Contact Email].
+      </p>
+      <p>
+        When you visit our website [Your Website URL] (the "Website"), and use our services, you trust us with your personal information. We take your privacy very seriously. In this privacy notice, we describe our privacy policy. We seek to explain to you in the clearest way possible what information we collect, how we use it and what rights you have in relation to it. We hope you take some time to read through it carefully, as it is important. If there are any terms in this privacy policy that you do not agree with, please discontinue use of our Sites and our services.
+      </p>
+      <p>
+        This privacy policy applies to all information collected through our website (such as [Your Website URL]), and/or any related services, sales, marketing or events (we refer to them collectively in this privacy policy as the "Services").
+      </p>
+
+      <h2>2. What Information Do We Collect?</h2>
+      <p>
+        <strong>Personal information you disclose to us</strong>
+      </p>
+      <p>
+        <em>In Short: We collect personal information that you provide to us.</em>
+      </p>
+      <p>
+        We collect personal information that you voluntarily provide to us when registering at the Services, expressing an interest in obtaining information about us or our products and services, when participating in activities on the Services or otherwise contacting us.
+      </p>
+      <p>
+        The personal information that we collect depends on the context of your interactions with us and the Services, the choices you make and the products and features you use. The personal information we collect can include the following: Name and Contact Data. We collect your first and last name, email address, postal address, phone number, and other similar contact data.
+      </p>
+      <p>
+        All personal information that you provide to us must be true, complete and accurate, and you must notify us of any changes to such personal information.
+      </p>
+
+      <p>
+        <strong>Information automatically collected</strong>
+      </p>
+      <p>
+        <em>In Short: Some information – such as IP address and/or browser and device characteristics – is collected automatically when you visit our Services.</em>
+      </p>
+      <p>
+        We automatically collect certain information when you visit, use or navigate the Services. This information does not reveal your specific identity (like your name or contact information) but may include device and usage information, such as your IP address, browser and device characteristics, operating system, language preferences, referring URLs, device name, country, location, information about how and when you use our Services and other technical information. This information is primarily needed to maintain the security and operation of our Services, and for our internal analytics and reporting purposes.
+      </p>
+      <p>
+        Like many businesses, we also collect information through cookies and similar technologies.
+      </p>
+
+      <h2>3. How Do We Use Your Information?</h2>
+      <p>
+        <em>In Short: We process your information for purposes based on legitimate business interests, the fulfillment of our contract with you, compliance with our legal obligations, and/or your consent.</em>
+      </p>
+      <p>
+        We use personal information collected via our Services for a variety of business purposes described below. We process your personal information for these purposes in reliance on our legitimate business interests, in order to enter into or perform a contract with you, with your consent, and/or for compliance with our legal obligations. We indicate the specific processing grounds we rely on next to each purpose listed below.
+      </p>
+      <ul>
+        <li>To facilitate account creation and logon process.</li>
+        <li>To send administrative information to you.</li>
+        <li>To protect our Services.</li>
+        <li>To enforce our terms, conditions and policies for business purposes, to comply with legal and regulatory requirements or in connection with our contract.</li>
+        <li>To respond to legal requests and prevent harm.</li>
+        <li>For other Business Purposes. We may use your information for other Business Purposes, such as data analysis, identifying usage trends, determining the effectiveness of our promotional campaigns and to evaluate and improve our Services, products, marketing and your experience.</li>
+      </ul>
+
+      <h2>4. Will Your Information Be Shared With Anyone?</h2>
+      <p>
+        <em>In Short: We only share information with your consent, to comply with laws, to provide you with services, to protect your rights, or to fulfill business obligations.</em>
+      </p>
+      <p>
+        We may process or share data based on the following legal basis:
+      </p>
+      <ul>
+        <li><strong>Consent:</strong> We may process your data if you have given us specific consent to use your personal information in a specific purpose.</li>
+        <li><strong>Legitimate Interests:</strong> We may process your data when it is reasonably necessary to achieve our legitimate business interests.</li>
+        <li><strong>Performance of a Contract:</strong> Where we have entered into a contract with you, we may process your personal information to fulfill the terms of our contract.</li>
+        <li><strong>Legal Obligations:</strong> We may disclose your information where we are legally required to do so in order to comply with applicable law, governmental requests, a judicial proceeding, court order, or legal process.</li>
+        <li><strong>Vital Interests:</strong> We may disclose your information where we believe it is necessary to investigate, prevent, or take action regarding potential violations of our policies, suspected fraud, situations involving potential threats to the safety of any person and illegal activities, or as evidence in litigation in which we are involved.</li>
+      </ul>
+
+      <h2>5. Do We Use Cookies and Other Tracking Technologies?</h2>
+      <p>
+        <em>In Short: We may use cookies and other tracking technologies to collect and store your information.</em>
+      </p>
+      <p>
+        We may use cookies and similar tracking technologies (like web beacons and pixels) to access or store information. Specific information about how we use such technologies and how you can refuse certain cookies is set out in our Cookie Policy.
+      </p>
+
+      <h2>6. How Long Do We Keep Your Information?</h2>
+      <p>
+        <em>In Short: We keep your information for as long as necessary to fulfill the purposes outlined in this privacy policy unless otherwise required by law.</em>
+      </p>
+      <p>
+        We will only keep your personal information for as long as it is necessary for the purposes set out in this privacy policy, unless a longer retention period is required or permitted by law (such as tax, accounting or other legal requirements). No purpose in this policy will require us keeping your personal information for longer than the period of time in which users have an account with us.
+      </p>
+
+      <h2>7. How Do We Keep Your Information Safe?</h2>
+      <p>
+        <em>In Short: We aim to protect your personal information through a system of organizational and technical security measures.</em>
+      </p>
+      <p>
+        We have implemented appropriate technical and organizational security measures designed to protect the security of any personal information we process. However, please also remember that we cannot guarantee that the internet itself is 100% secure. Although we will do our best to protect your personal information, transmission of personal information to and from our Services is at your own risk. You should only access the services within a secure environment.
+      </p>
+
+      <h2>8. What Are Your Privacy Rights?</h2>
+      <p>
+        <em>In Short: You may review, change, or terminate your account at any time.</em>
+      </p>
+      <p>
+        If you are resident in the European Economic Area and you believe we are unlawfully processing your personal information, you also have the right to complain to your local data protection supervisory authority. You can find their contact details here: [Link to EU Data Protection Authorities]
+      </p>
+
+      <h2>9. Controls for Do-Not-Track Features</h2>
+      <p>
+        Most web browsers and some mobile operating systems and mobile applications include a Do-Not-Track (“DNT”) feature or setting you can activate to signal your privacy preference not to have data about your online browsing activities monitored and collected. No uniform technology standard for recognizing and implementing DNT signals has been finalized. As such, we do not currently respond to DNT browser signals or any other mechanism that automatically communicates your choice not to be tracked online. If a standard for online tracking is adopted that we must follow in the future, we will inform you about that practice in a revised version of this privacy policy.
+      </p>
+
+      <h2>10. Do We Make Updates to This Policy?</h2>
+      <p>
+        <em>In Short: Yes, we will update this policy as necessary to stay compliant with relevant laws.</em>
+      </p>
+      <p>
+        We may update this privacy policy from time to time. The updated version will be indicated by an updated “Revised” date and the updated version will be effective as soon as it is accessible. If we make material changes to this privacy policy, we may notify you either by prominently posting a notice of such changes or by directly sending you a notification. We encourage you to review this privacy policy frequently to be informed of how we are protecting your information.
+      </p>
+
+      <h2>11. How Can You Contact Us About This Policy?</h2>
+      <p>
+        If you have questions or comments about this policy, you may email us at [Your Contact Email] or by post to:
+      </p>
+      <p>
+        [Your Company Name]<br />
+        [Your Company Address Line 1]<br />
+        [Your Company Address Line 2]<br />
+        [City, State, Zip/Postal Code]<br />
+        [Country]
+      </p>
+    </div>
+  );
+};
+
+export default PrivacyPolicy;

--- a/web-portal/tech-radar/src/pages/legal/TermsOfService.tsx
+++ b/web-portal/tech-radar/src/pages/legal/TermsOfService.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+
+const TermsOfService: React.FC = () => {
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif', lineHeight: '1.6' }}>
+      <h1>Terms of Service</h1>
+      <p>Last updated: [Date]</p>
+
+      <h2>1. Agreement to Terms</h2>
+      <p>
+        These Terms of Service constitute a legally binding agreement made between you, whether personally or on behalf of an entity (“you”) and [Your Company/Website Name] (“we,” “us” or “our”), concerning your access to and use of the [Your Website URL] website as well as any other media form, media channel, mobile website or mobile application related, linked, or otherwise connected thereto (collectively, the “Site”).
+      </p>
+      <p>
+        You agree that by accessing the Site, you have read, understood, and agree to be bound by all of these Terms of Service. If you do not agree with all of these Terms of Service, then you are expressly prohibited from using the Site and you must discontinue use immediately.
+      </p>
+      <p>
+        Supplemental terms and conditions or documents that may be posted on the Site from time to time are hereby expressly incorporated herein by reference. We reserve the right, in our sole discretion, to make changes or modifications to these Terms of Service at any time and for any reason.
+      </p>
+      <p>
+        We will alert you about any changes by updating the “Last updated” date of these Terms of Service, and you waive any right to receive specific notice of each such change. It is your responsibility to periodically review these Terms of Service to stay informed of updates. You will be subject to, and will be deemed to have been made aware of and to have accepted, the changes in any revised Terms of Service by your continued use of the Site after the date such revised Terms of Service are posted.
+      </p>
+
+      <h2>2. Intellectual Property Rights</h2>
+      <p>
+        Unless otherwise indicated, the Site is our proprietary property and all source code, databases, functionality, software, website designs, audio, video, text, photographs, and graphics on the Site (collectively, the “Content”) and the trademarks, service marks, and logos contained therein (the “Marks”) are owned or controlled by us or licensed to us, and are protected by copyright and trademark laws and various other intellectual property rights and unfair competition laws of the United States, foreign jurisdictions, and international conventions.
+      </p>
+      <p>
+        The Content and the Marks are provided on the Site “AS IS” for your information and personal use only. Except as expressly provided in these Terms of Service, no part of the Site and no Content or Marks may be copied, reproduced, aggregated, republished, uploaded, posted, publicly displayed, encoded, translated, transmitted, distributed, sold, licensed, or otherwise exploited for any commercial purpose whatsoever, without our express prior written permission.
+      </p>
+
+      <h2>3. User Representations</h2>
+      <p>By using the Site, you represent and warrant that:</p>
+      <ol>
+        <li>All registration information you submit will be true, accurate, current, and complete;</li>
+        <li>You will maintain the accuracy of such information and promptly update such registration information as necessary;</li>
+        <li>You have the legal capacity and you agree to comply with these Terms of Service;</li>
+        <li>You are not a minor in the jurisdiction in which you reside, or if a minor, you have received parental permission to use the Site;</li>
+        <li>You will not access the Site through automated or non-human means, whether through a bot, script or otherwise;</li>
+        <li>You will not use the Site for any illegal or unauthorized purpose;</li>
+        <li>Your use of the Site will not violate any applicable law or regulation.</li>
+      </ol>
+      <p>
+        If you provide any information that is untrue, inaccurate, not current, or incomplete, we have the right to suspend or terminate your account and refuse any and all current or future use of the Site (or any portion thereof).
+      </p>
+
+      <h2>4. Prohibited Activities</h2>
+      <p>You may not access or use the Site for any purpose other than that for which we make the Site available. The Site may not be used in connection with any commercial endeavors except those that are specifically endorsed or approved by us.</p>
+      <p>As a user of the Site, you agree not to:</p>
+      <ul>
+        <li>Systematically retrieve data or other content from the Site to create or compile, directly or indirectly, a collection, compilation, database, or directory without written permission from us.</li>
+        <li>Make any unauthorized use of the Site, including collecting usernames and/or email addresses of users by electronic or other means for the purpose of sending unsolicited email, or creating user accounts by automated means or under false pretenses.</li>
+        <li>Use a buying agent or purchasing agent to make purchases on the Site.</li>
+        <li>Use the Site to advertise or offer to sell goods and services.</li>
+        <li>Circumvent, disable, or otherwise interfere with security-related features of the Site, including features that prevent or restrict the use or copying of any Content or enforce limitations on the use of the Site and/or the Content contained therein.</li>
+        <li>Engage in unauthorized framing of or linking to the Site.</li>
+        <li>Trick, defraud, or mislead us and other users, especially in any attempt to learn sensitive account information such as user passwords.</li>
+        <li>Make improper use of our support services or submit false reports of abuse or misconduct.</li>
+        <li>Engage in any automated use of the system, such as using scripts to send comments or messages, or using any data mining, robots, or similar data gathering and extraction tools.</li>
+        <li>Interfere with, disrupt, or create an undue burden on the Site or the networks or services connected to the Site.</li>
+        <li>Attempt to impersonate another user or person or use the username of another user.</li>
+        <li>Sell or otherwise transfer your profile.</li>
+        <li>Use any information obtained from the Site in order to harass, abuse, or harm another person.</li>
+        <li>Use the Site as part of any effort to compete with us or otherwise use the Site and/or the Content for any revenue-generating endeavor or commercial enterprise.</li>
+      </ul>
+
+      <h2>5. Term and Termination</h2>
+      <p>
+        These Terms of Service shall remain in full force and effect while you use the Site. WITHOUT LIMITING ANY OTHER PROVISION OF THESE TERMS OF SERVICE, WE RESERVE THE RIGHT TO, IN OUR SOLE DISCRETION AND WITHOUT NOTICE OR LIABILITY, DENY ACCESS TO AND USE OF THE SITE (INCLUDING BLOCKING CERTAIN IP ADDRESSES), TO ANY PERSON FOR ANY REASON OR FOR NO REASON, INCLUDING WITHOUT LIMITATION FOR BREACH OF ANY REPRESENTATION, WARRANTY, OR COVENANT CONTAINED IN THESE TERMS OF SERVICE OR OF ANY APPLICABLE LAW OR REGULATION. WE MAY TERMINATE YOUR USE OR PARTICIPATION IN THE SITE OR DELETE YOUR ACCOUNT AND ANY CONTENT OR INFORMATION THAT YOU POSTED AT ANY TIME, WITHOUT WARNING, IN OUR SOLE DISCRETION.
+      </p>
+
+      <h2>6. Modifications and Interruptions</h2>
+      <p>
+        We reserve the right to change, modify, or remove the contents of the Site at any time or for any reason at our sole discretion without notice. However, we have no obligation to update any information on our Site. We also reserve the right to modify or discontinue all or part of the Site without notice at any time.
+      </p>
+      <p>
+        We will not be liable to you or any third party for any modification, price change, suspension, or discontinuance of the Site.
+      </p>
+      <p>
+        We cannot guarantee the Site will be available at all times. We may experience hardware, software, or other problems or need to perform maintenance related to the Site, resulting in interruptions, delays, or errors. We reserve the right to change, revise, update, suspend, discontinue, or otherwise modify the Site at any time or for any reason without notice to you.
+      </p>
+
+      <h2>7. Governing Law</h2>
+      <p>
+        These Terms of Service and your use of the Site are governed by and construed in accordance with the laws of [Your State/Country] applicable to agreements made and to be entirely performed within [Your State/Country], without regard to its conflict of law principles.
+      </p>
+
+      <h2>8. Dispute Resolution</h2>
+      <p>
+        Any legal action of whatever nature brought by either you or us (collectively, the “Parties” and individually, a “Party”) shall be commenced or prosecuted in the state and federal courts located in [Your County, Your State], and the Parties hereby consent to, and waive all defenses of lack of personal jurisdiction and forum non conveniens with respect to venue and jurisdiction in such state and federal courts.
+      </p>
+
+      <h2>9. Disclaimer</h2>
+      <p>
+        THE SITE IS PROVIDED ON AN AS-IS AND AS-AVAILABLE BASIS. YOU AGREE THAT YOUR USE OF THE SITE AND OUR SERVICES WILL BE AT YOUR SOLE RISK. TO THE FULLEST EXTENT PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, IN CONNECTION WITH THE SITE AND YOUR USE THEREOF, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE MAKE NO WARRANTIES OR REPRESENTATIONS ABOUT THE ACCURACY OR COMPLETENESS OF THE SITE’S CONTENT OR THE CONTENT OF ANY WEBSITES LINKED TO THE SITE AND WE WILL ASSUME NO LIABILITY OR RESPONSIBILITY FOR ANY (1) ERRORS, MISTAKES, OR INACCURACIES OF CONTENT AND MATERIALS, (2) PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO AND USE OF THE SITE, (3) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SECURE SERVERS AND/OR ANY AND ALL PERSONAL INFORMATION AND/OR FINANCIAL INFORMATION STORED THEREIN, (4) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE SITE, (5) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE WHICH MAY BE TRANSMITTED TO OR THROUGH THE SITE BY ANY THIRD PARTY, AND/OR (6) ANY ERRORS OR OMISSIONS IN ANY CONTENT AND MATERIALS OR FOR ANY LOSS OR DAMAGE OF ANY KIND INCURRED AS A RESULT OF THE USE OF ANY CONTENT POSTED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE VIA THE SITE.
+      </p>
+
+      <h2>10. Limitation of Liability</h2>
+      <p>
+        IN NO EVENT WILL WE OR OUR DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT, INDIRECT, CONSEQUENTIAL, EXEMPLARY, INCIDENTAL, SPECIAL, OR PUNITIVE DAMAGES, INCLUDING LOST PROFIT, LOST REVENUE, LOSS OF DATA, OR OTHER DAMAGES ARISING FROM YOUR USE OF THE SITE, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </p>
+
+      <h2>11. Indemnification</h2>
+      <p>
+        You agree to defend, indemnify, and hold us harmless, including our subsidiaries, affiliates, and all of our respective officers, agents, partners, and employees, from and against any loss, damage, liability, claim, or demand, including reasonable attorneys’ fees and expenses, made by any third party due to or arising out of: (1) use of the Site; (2) breach of these Terms of Service; (3) any breach of your representations and warranties set forth in these Terms of Service; (4) your violation of the rights of a third party, including but not limited to intellectual property rights; or (5) any overt harmful act toward any other user of the Site with whom you connected via the Site.
+      </p>
+
+      <h2>12. User Data</h2>
+      <p>
+        We will maintain certain data that you transmit to the Site for the purpose of managing the performance of the Site, as well as data relating to your use of the Site. Although we perform regular routine backups of data, you are solely responsible for all data that you transmit or that relates to any activity you have undertaken using the Site. You agree that we shall have no liability to you for any loss or corruption of any such data, and you hereby waive any right of action against us arising from any such loss or corruption of such data.
+      </p>
+
+      <h2>13. Miscellaneous</h2>
+      <p>
+        These Terms of Service and any policies or operating rules posted by us on the Site or in respect to the Site constitute the entire agreement and understanding between you and us. Our failure to exercise or enforce any right or provision of these Terms of Service shall not operate as a waiver of such right or provision.
+      </p>
+      <p>
+        If any provision or part of a provision of these Terms of Service is determined to be unlawful, void, or unenforceable, that provision or part of the provision is deemed severable from these Terms of Service and does not affect the validity and enforceability of any remaining provisions.
+      </p>
+
+      <h2>14. Contact Us</h2>
+      <p>
+        In order to resolve a complaint regarding the Site or to receive further information regarding use of the Site, please contact us at:
+      </p>
+      <p>
+        [Your Company Name]<br />
+        [Your Company Address Line 1]<br />
+        [Your Company Address Line 2]<br />
+        [City, State, Zip/Postal Code]<br />
+        [Country]<br />
+        [Your Contact Email]
+      </p>
+    </div>
+  );
+};
+
+export default TermsOfService;


### PR DESCRIPTION
- Created placeholder components for Privacy Policy, Terms of Service, and Impressum.
- Added routes in App.tsx for these pages.
- Updated footer links to point to the new legal pages.