### PR TITLE
Fix: Ensure correct part directives for generated files

### DIFF
--- a/lib/src/features/a_ideation/data/multi_agent_providers.dart
+++ b/lib/src/features/a_ideation/data/multi_agent_providers.dart
@@ -9,7 +9,6 @@ import 'game_engine_agent_service.dart';
 import 'agent_orchestrator_service.dart' as orchestrator;
 
 part 'multi_agent_providers.g.dart';
-// part 'multi_agent_providers.freezed.dart'; // Commented out if file does not exist
 
 // ============================================================================
 // SERVICE PROVIDERS


### PR DESCRIPTION
Removed an unnecessary commented-out `part` directive for a non-existent `.freezed.dart` file in `multi_agent_providers.dart` as no classes in that file utilize the @freezed annotation.

Verified that all other relevant `part` directives for Freezed, Riverpod, and JsonSerializable generated files are active and correctly associated with their source files.