### PR TITLE
Refactor: Remove dead null-aware expressions in AIAnalyticsSystem

### DIFF
--- a/lib/src/core/ai/ai_analytics_system.dart
+++ b/lib/src/core/ai/ai_analytics_system.dart
@@ -306,9 +306,9 @@ class AIAnalyticsSystem {
     for (final taskType in _responseTimes.keys) {
       metrics[taskType] = {
         'average_response_time': _calculateAverage(_responseTimes[taskType]!),
-        'average_confidence': _calculateAverage(_confidenceScores[taskType] ?? []),
-        'average_satisfaction': _calculateAverage(_userSatisfaction[taskType] ?? []),
-        'total_requests': _usageCounts[taskType] ?? 0,
+        'average_confidence': _calculateAverage(_confidenceScores[taskType]!),
+        'average_satisfaction': _calculateAverage(_userSatisfaction[taskType]!),
+        'total_requests': _usageCounts[taskType]!,
       };
     }
     


### PR DESCRIPTION
Removed three instances of redundant null-aware operators (`??`) in the `_getPerformanceMetrics` method of `AIAnalyticsSystem`.

The analysis confirmed that the left-hand side of these expressions is guaranteed to be non-null within the loop's context, allowing for safe replacement with the null assertion operator (`!`).

This change simplifies the code without altering its logic. Testing could not be performed in the current environment.