### PR TITLE
Fix: Update deprecated Font Awesome icons

### DIFF
--- a/docs/features/ai/research_agent_ui.md
+++ b/docs/features/ai/research_agent_ui.md
@@ -32,7 +32,7 @@ Widget _buildSourceBadge(ResearchSource source) {
         children: [
           FaIcon(sourceInfo['icon']), // Source-spezifisches Icon
           Text(sourceInfo['name']),   // Source Name
-          FaIcon(FontAwesomeIcons.externalLinkAlt), // Link Icon
+          FaIcon(FontAwesomeIcons.externalLink), // Link Icon
         ],
       ),
     ),

--- a/lib/src/features/a_ideation/presentation/research_agent_screen.dart
+++ b/lib/src/features/a_ideation/presentation/research_agent_screen.dart
@@ -140,7 +140,7 @@ class _ResearchAgentScreenState extends ConsumerState<ResearchAgentScreen>
             ),
             const SizedBox(width: 4),
             const FaIcon(
-              FontAwesomeIcons.externalLinkAlt,
+              FontAwesomeIcons.externalLink,
               size: 10,
               color: Colors.white,
             ),
@@ -263,7 +263,7 @@ class _ResearchAgentScreenState extends ConsumerState<ResearchAgentScreen>
                       const SnackBar(content: Text('PDF Export - Coming Soon!')),
                     );
                   },
-                  icon: const FaIcon(FontAwesomeIcons.filePdf),
+                  icon: const FaIcon(FontAwesomeIcons.regularFilePdf),
                   label: const Text('Export PDF'),
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.red.shade600,
@@ -314,7 +314,7 @@ class _ResearchAgentScreenState extends ConsumerState<ResearchAgentScreen>
         centerTitle: true,
         actions: [
           IconButton(
-            icon: const FaIcon(FontAwesomeIcons.questionCircle),
+            icon: const FaIcon(FontAwesomeIcons.regularQuestionCircle),
             onPressed: () {
               showDialog(
                 context: context,
@@ -456,7 +456,7 @@ class _ResearchAgentScreenState extends ConsumerState<ResearchAgentScreen>
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             const FaIcon(
-                              FontAwesomeIcons.exclamationTriangle,
+                              FontAwesomeIcons.triangleExclamation,
                               size: 48,
                               color: Colors.red,
                             ),

--- a/lib/src/features/a_ideation/presentation/research_agent_screen_new.dart
+++ b/lib/src/features/a_ideation/presentation/research_agent_screen_new.dart
@@ -147,7 +147,7 @@ class _ResearchAgentScreenNewState extends ConsumerState<ResearchAgentScreenNew>
             ),
             const SizedBox(width: 4),
             const FaIcon(
-              FontAwesomeIcons.externalLinkAlt,
+              FontAwesomeIcons.externalLink,
               size: 10,
               color: Colors.white,
             ),
@@ -270,7 +270,7 @@ class _ResearchAgentScreenNewState extends ConsumerState<ResearchAgentScreenNew>
                       const SnackBar(content: Text('PDF Export - Coming Soon!')),
                     );
                   },
-                  icon: const FaIcon(FontAwesomeIcons.filePdf),
+                  icon: const FaIcon(FontAwesomeIcons.regularFilePdf),
                   label: const Text('Export PDF'),
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.red.shade600,
@@ -321,7 +321,7 @@ class _ResearchAgentScreenNewState extends ConsumerState<ResearchAgentScreenNew>
         centerTitle: true,
         actions: [
           IconButton(
-            icon: const FaIcon(FontAwesomeIcons.questionCircle),
+            icon: const FaIcon(FontAwesomeIcons.regularQuestionCircle),
             onPressed: () {
               showDialog(
                 context: context,
@@ -463,7 +463,7 @@ class _ResearchAgentScreenNewState extends ConsumerState<ResearchAgentScreenNew>
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             const FaIcon(
-                              FontAwesomeIcons.exclamationTriangle,
+                              FontAwesomeIcons.triangleExclamation,
                               size: 48,
                               color: Colors.red,
                             ),


### PR DESCRIPTION
Replaced `externalLinkAlt` with `externalLink` and `exclamationTriangle` with `triangleExclamation`. Added `regular` style prefix to `filePdf` and `questionCircle` to use current Font Awesome versions.

Skipped comprehensive deprecated Flutter property updates and `flutter analyze` due to environmental constraints and at user request.