### PR TITLE
Fix: Replace deprecated members and address navigation TODOs

### DIFF
--- a/lib/src/features/a_ideation/presentation/create_project_screen.dart
+++ b/lib/src/features/a_ideation/presentation/create_project_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class CreateProjectScreen extends StatelessWidget {
+  const CreateProjectScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create Project'),
+      ),
+      body: const Center(
+        child: Text('Create Project Screen - Placeholder'),
+      ),
+    );
+  }
+}

--- a/lib/src/features/a_ideation/presentation/edit_profile_screen.dart
+++ b/lib/src/features/a_ideation/presentation/edit_profile_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class EditProfileScreen extends StatelessWidget {
+  const EditProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Edit Profile'),
+      ),
+      body: const Center(
+        child: Text('Edit Profile Screen - Placeholder'),
+      ),
+    );
+  }
+}

--- a/lib/src/features/a_ideation/presentation/profile_screen.dart
+++ b/lib/src/features/a_ideation/presentation/profile_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:project_jambam/src/features/a_ideation/presentation/edit_profile_screen.dart';
+import 'package:project_jambam/src/features/a_ideation/presentation/settings_screen.dart';
 
 class ProfileScreen extends ConsumerStatefulWidget {
   const ProfileScreen({super.key});
@@ -36,13 +38,19 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
           IconButton(
             icon: const Icon(Icons.edit),
             onPressed: () {
-              // TODO: Edit profile
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const EditProfileScreen()),
+              );
             },
           ),
           IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () {
-              // TODO: Settings
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const SettingsScreen()),
+              );
             },
           ),
         ],
@@ -138,7 +146,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
                       Container(
                         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                         decoration: BoxDecoration(
-                          color: Colors.white.withOpacity(0.2),
+                          color: Colors.white.withAlpha((255 * 0.2).round()),
                           borderRadius: BorderRadius.circular(12),
                         ),
                         child: const Text(
@@ -208,7 +216,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
         Text(
           label,
           style: TextStyle(
-            color: color.withOpacity(0.8),
+            color: color.withAlpha((255 * 0.8).round()),
             fontSize: 12,
           ),
         ),
@@ -278,7 +286,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
         Container(
           padding: const EdgeInsets.all(8),
           decoration: BoxDecoration(
-            color: color.withOpacity(0.1),
+            color: color.withAlpha((255 * 0.1).round()),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Icon(icon, color: color, size: 20),
@@ -415,7 +423,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
           const SizedBox(height: 4),
           LinearProgressIndicator(
             value: level,
-            backgroundColor: Colors.grey.withOpacity(0.3),
+            backgroundColor: Colors.grey.withAlpha((255 * 0.3).round()),
             valueColor: AlwaysStoppedAnimation<Color>(color),
             minHeight: 6,
           ),
@@ -476,7 +484,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
             decoration: BoxDecoration(
-              color: statusColor.withOpacity(0.1),
+              color: statusColor.withAlpha((255 * 0.1).round()),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Text(
@@ -550,7 +558,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: Colors.blue.withOpacity(0.1),
+                color: Colors.blue.withAlpha((255 * 0.1).round()),
                 borderRadius: BorderRadius.circular(20),
               ),
               child: const Text(
@@ -577,7 +585,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
           width: 50,
           height: 50,
           decoration: BoxDecoration(
-            color: color.withOpacity(0.1),
+            color: color.withAlpha((255 * 0.1).round()),
             borderRadius: BorderRadius.circular(25),
           ),
           child: Icon(Icons.business, color: color, size: 24),
@@ -593,7 +601,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                 decoration: BoxDecoration(
-                  color: Colors.green.withOpacity(0.1),
+                  color: Colors.green.withAlpha((255 * 0.1).round()),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: const Text(
@@ -617,7 +625,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                   decoration: BoxDecoration(
-                    color: color.withOpacity(0.1),
+                    color: color.withAlpha((255 * 0.1).round()),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
@@ -636,7 +644,10 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
         trailing: IconButton(
           icon: const Icon(Icons.arrow_forward_ios),
           onPressed: () {
-            // TODO: Navigate to organization
+            // For now, show a snackbar. Replace with actual navigation logic.
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Navigate to $name - Coming Soon!')),
+            );
           },
         ),
       ),
@@ -679,7 +690,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
             width: 40,
             height: 40,
             decoration: BoxDecoration(
-              color: color.withOpacity(0.1),
+              color: color.withAlpha((255 * 0.1).round()),
               borderRadius: BorderRadius.circular(20),
             ),
             child: Icon(Icons.people, color: color, size: 20),
@@ -774,7 +785,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: Colors.amber.withOpacity(0.1),
+                color: Colors.amber.withAlpha((255 * 0.1).round()),
                 borderRadius: BorderRadius.circular(20),
               ),
               child: const Text(
@@ -801,7 +812,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
           width: 50,
           height: 50,
           decoration: BoxDecoration(
-            color: unlocked ? color : Colors.grey.withOpacity(0.3),
+            color: unlocked ? color : Colors.grey.withAlpha((255 * 0.3).round()),
             borderRadius: BorderRadius.circular(25),
           ),
           child: Icon(
@@ -891,7 +902,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: Colors.blue.withOpacity(0.1),
+                color: Colors.blue.withAlpha((255 * 0.1).round()),
                 borderRadius: BorderRadius.circular(20),
               ),
               child: const Text(
@@ -917,7 +928,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
         leading: Container(
           padding: const EdgeInsets.all(8),
           decoration: BoxDecoration(
-            color: color.withOpacity(0.1),
+              color: color.withAlpha((255 * 0.1).round()),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Icon(icon, color: color, size: 20),

--- a/lib/src/features/a_ideation/presentation/project_details_screen.dart
+++ b/lib/src/features/a_ideation/presentation/project_details_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class ProjectDetailsScreen extends StatelessWidget {
+  final String projectId;
+
+  const ProjectDetailsScreen({super.key, required this.projectId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Project Details: $projectId'),
+      ),
+      body: Center(
+        child: Text('Project Details Screen for $projectId - Placeholder'),
+      ),
+    );
+  }
+}

--- a/lib/src/features/a_ideation/presentation/projects_screen.dart
+++ b/lib/src/features/a_ideation/presentation/projects_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:project_jambam/src/features/a_ideation/presentation/create_project_screen.dart';
+import 'package:project_jambam/src/features/a_ideation/presentation/project_details_screen.dart';
 
 class ProjectsScreen extends ConsumerStatefulWidget {
   const ProjectsScreen({super.key});
@@ -30,7 +32,7 @@ class _ProjectsScreenState extends ConsumerState<ProjectsScreen>
       body: Column(
         children: [
           Container(
-            color: Theme.of(context).primaryColor.withOpacity(0.1),
+            color: Theme.of(context).primaryColor.withAlpha((255 * 0.1).round()),
             child: TabBar(
               controller: _tabController,
               labelColor: Theme.of(context).primaryColor,
@@ -59,9 +61,9 @@ class _ProjectsScreenState extends ConsumerState<ProjectsScreen>
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          // TODO: Navigate to create project screen
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Create Project - Coming Soon!')),
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => const CreateProjectScreen()),
           );
         },
         child: const Icon(Icons.add),
@@ -93,9 +95,11 @@ class AllProjectsTab extends StatelessWidget {
             subtitle: Text(_getProjectDescription(index)),
             trailing: const Icon(Icons.arrow_forward_ios),
             onTap: () {
-              // TODO: Navigate to project details
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Project ${index + 1} Details - Coming Soon!')),
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => ProjectDetailsScreen(projectId: 'project_${index + 1}'),
+                ),
               );
             },
           ),
@@ -156,9 +160,11 @@ class MyProjectsTab extends StatelessWidget {
             subtitle: Text(_getStatusText(index)),
             trailing: const Icon(Icons.arrow_forward_ios),
             onTap: () {
-              // TODO: Navigate to my project details
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('My Project ${index + 1} Details - Coming Soon!')),
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => ProjectDetailsScreen(projectId: 'my_project_${index + 1}'),
+                ),
               );
             },
           ),
@@ -211,9 +217,11 @@ class CollaboratingProjectsTab extends StatelessWidget {
             subtitle: Text('Team: Innovation Squad ${index + 1}'),
             trailing: const Icon(Icons.arrow_forward_ios),
             onTap: () {
-              // TODO: Navigate to collaborating project details
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Collaborating Project ${index + 1} Details - Coming Soon!')),
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => ProjectDetailsScreen(projectId: 'collab_project_${index + 1}'),
+                ),
               );
             },
           ),
@@ -246,9 +254,11 @@ class ArchivedProjectsTab extends StatelessWidget {
             subtitle: Text('Completed ${(index + 1) * 30} days ago'),
             trailing: const Icon(Icons.arrow_forward_ios),
             onTap: () {
-              // TODO: Navigate to archived project details
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Archived Project ${index + 1} Details - Coming Soon!')),
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => ProjectDetailsScreen(projectId: 'archived_project_${index + 1}'),
+                ),
               );
             },
           ),

--- a/lib/src/features/a_ideation/presentation/prototype_management_screen.dart
+++ b/lib/src/features/a_ideation/presentation/prototype_management_screen.dart
@@ -163,7 +163,7 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
         Text(
           label,
           style: TextStyle(
-            color: color.withOpacity(0.8),
+            color: color.withAlpha((255 * 0.8).round()),
             fontSize: 12,
           ),
         ),
@@ -195,7 +195,7 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                   decoration: BoxDecoration(
-                    color: Colors.indigo.withOpacity(0.1),
+                    color: Colors.indigo.withAlpha((255 * 0.1).round()),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: const Text(
@@ -245,9 +245,9 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
       margin: const EdgeInsets.only(bottom: 12),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
+        color: color.withAlpha((255 * 0.1).round()),
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: color.withOpacity(0.3)),
+        border: Border.all(color: color.withAlpha((255 * 0.3).round())),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -278,7 +278,7 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
-                  color: color.withOpacity(0.2),
+                  color: color.withAlpha((255 * 0.2).round()),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Text(
@@ -343,7 +343,7 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
           const SizedBox(height: 12),
           LinearProgressIndicator(
             value: int.parse(progress.replaceAll('%', '')) / 100,
-            backgroundColor: Colors.grey.withOpacity(0.3),
+            backgroundColor: Colors.grey.withAlpha((255 * 0.3).round()),
             valueColor: AlwaysStoppedAnimation<Color>(color),
             minHeight: 6,
           ),
@@ -448,9 +448,9 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
+        color: color.withAlpha((255 * 0.1).round()),
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: color.withOpacity(0.3)),
+        border: Border.all(color: color.withAlpha((255 * 0.3).round())),
       ),
       child: Column(
         children: [
@@ -584,7 +584,7 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: Colors.indigo.withOpacity(0.1),
+                color: Colors.indigo.withAlpha((255 * 0.1).round()),
                 borderRadius: BorderRadius.circular(20),
               ),
               child: const Text(
@@ -634,9 +634,9 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
+        color: color.withAlpha((255 * 0.1).round()),
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: color.withOpacity(0.3)),
+        border: Border.all(color: color.withAlpha((255 * 0.3).round())),
       ),
       child: Row(
         children: [
@@ -847,7 +847,7 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: Colors.indigo.withOpacity(0.1),
+                color: Colors.indigo.withAlpha((255 * 0.1).round()),
                 borderRadius: BorderRadius.circular(20),
               ),
               child: const Text(
@@ -897,9 +897,9 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
+        color: color.withAlpha((255 * 0.1).round()),
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: color.withOpacity(0.3)),
+        border: Border.all(color: color.withAlpha((255 * 0.3).round())),
       ),
       child: Row(
         children: [
@@ -939,7 +939,7 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
             decoration: BoxDecoration(
-              color: color.withOpacity(0.2),
+              color: color.withAlpha((255 * 0.2).round()),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Text(
@@ -989,10 +989,10 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: connected ? color.withOpacity(0.1) : Colors.grey.withOpacity(0.05),
+        color: connected ? color.withAlpha((255 * 0.1).round()) : Colors.grey.withAlpha((255 * 0.05).round()),
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: connected ? color : Colors.grey.withOpacity(0.3),
+          color: connected ? color : Colors.grey.withAlpha((255 * 0.3).round()),
         ),
       ),
       child: Row(
@@ -1131,7 +1131,7 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: Colors.indigo.withOpacity(0.1),
+                color: Colors.indigo.withAlpha((255 * 0.1).round()),
                 borderRadius: BorderRadius.circular(20),
               ),
               child: const Text(
@@ -1181,16 +1181,16 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
+        color: color.withAlpha((255 * 0.1).round()),
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: color.withOpacity(0.3)),
+        border: Border.all(color: color.withAlpha((255 * 0.3).round())),
       ),
       child: Row(
         children: [
           Container(
             padding: const EdgeInsets.all(8),
             decoration: BoxDecoration(
-              color: color.withOpacity(0.2),
+              color: color.withAlpha((255 * 0.2).round()),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Icon(Icons.work, color: Colors.indigo),
@@ -1208,7 +1208,7 @@ class _PrototypeManagementScreenState extends ConsumerState<PrototypeManagementS
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
             decoration: BoxDecoration(
-              color: color.withOpacity(0.2),
+                color: color.withAlpha((255 * 0.2).round()),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Text(

--- a/lib/src/features/a_ideation/presentation/simple_jams_screen.dart
+++ b/lib/src/features/a_ideation/presentation/simple_jams_screen.dart
@@ -30,7 +30,7 @@ class _JamsScreenState extends ConsumerState<JamsScreen>
       body: Column(
         children: [
           Container(
-            color: Theme.of(context).primaryColor.withOpacity(0.1),
+            color: Theme.of(context).primaryColor.withAlpha((255 * 0.1).round()),
             child: TabBar(
               controller: _tabController,
               labelColor: Theme.of(context).primaryColor,

--- a/lib/src/features/a_ideation/presentation/simple_projects_screen.dart
+++ b/lib/src/features/a_ideation/presentation/simple_projects_screen.dart
@@ -30,7 +30,7 @@ class _ProjectsScreenState extends ConsumerState<ProjectsScreen>
       body: Column(
         children: [
           Container(
-            color: Theme.of(context).primaryColor.withOpacity(0.1),
+            color: Theme.of(context).primaryColor.withAlpha((255 * 0.1).round()),
             child: TabBar(
               controller: _tabController,
               labelColor: Theme.of(context).primaryColor,

--- a/lib/src/features/a_ideation/presentation/terminology_settings_screen.dart
+++ b/lib/src/features/a_ideation/presentation/terminology_settings_screen.dart
@@ -67,7 +67,7 @@ class TerminologySettingsScreen extends ConsumerWidget {
                     Text(
                       'Customize the app language and terminology to match your preferences',
                       style: TextStyle(
-                        color: Colors.white.withOpacity(0.9),
+                        color: Colors.white.withAlpha((255 * 0.9).round()),
                         fontSize: 16,
                       ),
                     ),
@@ -163,7 +163,7 @@ class TerminologySettingsScreen extends ConsumerWidget {
                 Container(
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
-                    color: color.withOpacity(0.1),
+                    color: color.withAlpha((255 * 0.1).round()),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Icon(icon, color: color, size: 24),
@@ -215,16 +215,16 @@ class TerminologySettingsScreen extends ConsumerWidget {
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: isSelected ? color : Colors.grey.withOpacity(0.3),
+          color: isSelected ? color : Colors.grey.withAlpha((255 * 0.3).round()),
           width: isSelected ? 2 : 1,
         ),
-        color: isSelected ? color.withOpacity(0.1) : Colors.transparent,
+        color: isSelected ? color.withAlpha((255 * 0.1).round()) : Colors.transparent,
       ),
       child: ListTile(
         leading: Container(
           padding: const EdgeInsets.all(8),
           decoration: BoxDecoration(
-            color: color.withOpacity(0.1),
+            color: color.withAlpha((255 * 0.1).round()),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Icon(icon, color: color, size: 24),
@@ -261,10 +261,10 @@ class TerminologySettingsScreen extends ConsumerWidget {
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: isSelected ? Colors.purple : Colors.grey.withOpacity(0.3),
+          color: isSelected ? Colors.purple : Colors.grey.withAlpha((255 * 0.3).round()),
           width: isSelected ? 2 : 1,
         ),
-        color: isSelected ? Colors.purple.withOpacity(0.1) : Colors.transparent,
+        color: isSelected ? Colors.purple.withAlpha((255 * 0.1).round()) : Colors.transparent,
       ),
       child: ListTile(
         leading: Text(
@@ -303,7 +303,7 @@ class TerminologySettingsScreen extends ConsumerWidget {
                 Container(
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
-                    color: Colors.orange.withOpacity(0.1),
+                    color: Colors.orange.withAlpha((255 * 0.1).round()),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: const Icon(Icons.preview, color: Colors.orange, size: 24),
@@ -324,7 +324,7 @@ class TerminologySettingsScreen extends ConsumerWidget {
               decoration: BoxDecoration(
                 color: Colors.grey[100],
                 borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.withOpacity(0.3)),
+                 border: Border.all(color: Colors.grey.withAlpha((255 * 0.3).round())),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -399,7 +399,7 @@ class TerminologySettingsScreen extends ConsumerWidget {
                 Container(
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
-                    color: Colors.grey.withOpacity(0.1),
+                    color: Colors.grey.withAlpha((255 * 0.1).round()),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: const Icon(Icons.info, color: Colors.grey, size: 24),

--- a/lib/src/features/a_ideation/presentation/workflow_system_screen.dart
+++ b/lib/src/features/a_ideation/presentation/workflow_system_screen.dart
@@ -163,7 +163,7 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
         Text(
           label,
           style: TextStyle(
-            color: color.withOpacity(0.8),
+            color: color.withAlpha((255 * 0.8).round()),
             fontSize: 12,
           ),
         ),
@@ -195,7 +195,7 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                   decoration: BoxDecoration(
-                    color: Colors.deepPurple.withOpacity(0.1),
+                    color: Colors.deepPurple.withAlpha((255 * 0.1).round()),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: const Text(
@@ -245,9 +245,9 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
       margin: const EdgeInsets.only(bottom: 12),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
+        color: color.withAlpha((255 * 0.1).round()),
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: color.withOpacity(0.3)),
+        border: Border.all(color: color.withAlpha((255 * 0.3).round())),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -278,7 +278,7 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
-                  color: color.withOpacity(0.2),
+                  color: color.withAlpha((255 * 0.2).round()),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Text(
@@ -343,7 +343,7 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
           const SizedBox(height: 12),
           LinearProgressIndicator(
             value: int.parse(progress.replaceAll('%', '')) / 100,
-            backgroundColor: Colors.grey.withOpacity(0.3),
+            backgroundColor: Colors.grey.withAlpha((255 * 0.3).round()),
             valueColor: AlwaysStoppedAnimation<Color>(color),
             minHeight: 6,
           ),
@@ -448,9 +448,9 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
+        color: color.withAlpha((255 * 0.1).round()),
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: color.withOpacity(0.3)),
+        border: Border.all(color: color.withAlpha((255 * 0.3).round())),
       ),
       child: Column(
         children: [
@@ -598,7 +598,7 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: Colors.deepPurple.withOpacity(0.1),
+                color: Colors.deepPurple.withAlpha((255 * 0.1).round()),
                 borderRadius: BorderRadius.circular(20),
               ),
               child: const Text(
@@ -661,9 +661,9 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
+        color: color.withAlpha((255 * 0.1).round()),
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: color.withOpacity(0.3)),
+        border: Border.all(color: color.withAlpha((255 * 0.3).round())),
       ),
       child: Column(
         children: [
@@ -870,7 +870,7 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: Colors.deepPurple.withOpacity(0.1),
+                color: Colors.deepPurple.withAlpha((255 * 0.1).round()),
                 borderRadius: BorderRadius.circular(20),
               ),
               child: const Text(
@@ -920,10 +920,10 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: enabled ? color.withOpacity(0.1) : Colors.grey.withOpacity(0.05),
+        color: enabled ? color.withAlpha((255 * 0.1).round()) : Colors.grey.withAlpha((255 * 0.05).round()),
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: enabled ? color : Colors.grey.withOpacity(0.3),
+          color: enabled ? color : Colors.grey.withAlpha((255 * 0.3).round()),
         ),
       ),
       child: Row(
@@ -960,7 +960,7 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
             onChanged: (value) {
               // TODO: Toggle automation
             },
-            activeColor: color,
+            activeThumbColor: color,
           ),
         ],
       ),
@@ -1000,10 +1000,10 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: enabled ? color.withOpacity(0.1) : Colors.grey.withOpacity(0.05),
+        color: enabled ? color.withAlpha((255 * 0.1).round()) : Colors.grey.withAlpha((255 * 0.05).round()),
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: enabled ? color : Colors.grey.withOpacity(0.3),
+          color: enabled ? color : Colors.grey.withAlpha((255 * 0.3).round()),
         ),
       ),
       child: Row(
@@ -1040,7 +1040,7 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
             onChanged: (value) {
               // TODO: Toggle trigger
             },
-            activeColor: color,
+            activeThumbColor: color,
           ),
         ],
       ),
@@ -1147,7 +1147,7 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: Colors.deepPurple.withOpacity(0.1),
+                color: Colors.deepPurple.withAlpha((255 * 0.1).round()),
                 borderRadius: BorderRadius.circular(20),
               ),
               child: const Text(
@@ -1236,7 +1236,7 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
         Container(
           padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
           decoration: BoxDecoration(
-            color: color.withOpacity(0.1),
+              color: color.withAlpha((255 * 0.1).round()),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Text(
@@ -1284,9 +1284,9 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
+        color: color.withAlpha((255 * 0.1).round()),
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: color.withOpacity(0.3)),
+        border: Border.all(color: color.withAlpha((255 * 0.3).round())),
       ),
       child: Row(
         children: [
@@ -1369,9 +1369,9 @@ class _WorkflowSystemScreenState extends ConsumerState<WorkflowSystemScreen>
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
+        color: color.withAlpha((255 * 0.1).round()),
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: color.withOpacity(0.3)),
+        border: Border.all(color: color.withAlpha((255 * 0.3).round())),
       ),
       child: Row(
         children: [


### PR DESCRIPTION
- Replaced deprecated `withOpacity` with `withAlpha` and `activeColor` with `activeThumbColor` across multiple files.
- Added placeholder screens and navigation for:
  - Profile: Edit Profile, Settings
  - Projects: Create Project, Project Details
- Added placeholder SnackBar messages for other TODOs that require further implementation details.