### PR TITLE
Feat: Implement navigation for TODOs in Jams and Labs screens

### DIFF
--- a/lib/src/features/a_ideation/presentation/jams_screen.dart
+++ b/lib/src/features/a_ideation/presentation/jams_screen.dart
@@ -59,10 +59,7 @@ class _JamsScreenState extends ConsumerState<JamsScreen>
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          // TODO: Navigate to create jam screen
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Create Jam - Coming Soon!')),
-          );
+          Navigator.pushNamed(context, '/create-jam');
         },
         child: const Icon(Icons.add),
       ),
@@ -90,10 +87,7 @@ class AllJamsTab extends StatelessWidget {
             subtitle: Text('A fantastic game jam experience'),
             trailing: const Icon(Icons.arrow_forward_ios),
             onTap: () {
-              // TODO: Navigate to jam details
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Jam ${index + 1} Details - Coming Soon!')),
-              );
+              Navigator.pushNamed(context, '/jam-details', arguments: {'jamId': index + 1});
             },
           ),
         );
@@ -125,10 +119,7 @@ class MyJamsTab extends StatelessWidget {
             subtitle: Text(index == 0 ? 'In Progress' : 'Completed'),
             trailing: const Icon(Icons.arrow_forward_ios),
             onTap: () {
-              // TODO: Navigate to my jam details
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('My Jam ${index + 1} Details - Coming Soon!')),
-              );
+              Navigator.pushNamed(context, '/my-jam-details', arguments: {'jamId': index + 1});
             },
           ),
         );
@@ -160,10 +151,7 @@ class ParticipatingJamsTab extends StatelessWidget {
             subtitle: Text('Team: Awesome Squad ${index + 1}'),
             trailing: const Icon(Icons.arrow_forward_ios),
             onTap: () {
-              // TODO: Navigate to participating jam details
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Participating Jam ${index + 1} Details - Coming Soon!')),
-              );
+              Navigator.pushNamed(context, '/participating-jam-details', arguments: {'jamId': index + 1});
             },
           ),
         );
@@ -195,10 +183,7 @@ class UpcomingJamsTab extends StatelessWidget {
             subtitle: Text('Starts in ${(index + 1) * 7} days'),
             trailing: const Icon(Icons.arrow_forward_ios),
             onTap: () {
-              // TODO: Navigate to upcoming jam details
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Upcoming Jam ${index + 1} Details - Coming Soon!')),
-              );
+              Navigator.pushNamed(context, '/upcoming-jam-details', arguments: {'jamId': index + 1});
             },
           ),
         );

--- a/lib/src/features/a_ideation/presentation/labs_screen.dart
+++ b/lib/src/features/a_ideation/presentation/labs_screen.dart
@@ -36,13 +36,13 @@ class _LabsScreenState extends ConsumerState<LabsScreen>
           IconButton(
             icon: const Icon(Icons.science),
             onPressed: () {
-              // TODO: Lab settings
+              Navigator.pushNamed(context, '/lab-settings');
             },
           ),
           IconButton(
             icon: const Icon(Icons.help),
             onPressed: () {
-              // TODO: Lab help
+              Navigator.pushNamed(context, '/lab-help');
             },
           ),
         ],
@@ -305,7 +305,7 @@ class _LabsScreenState extends ConsumerState<LabsScreen>
           IconButton(
             icon: const Icon(Icons.play_arrow),
             onPressed: () {
-              // TODO: Continue experiment
+              Navigator.pushNamed(context, '/continue-experiment', arguments: {'experimentTitle': title});
             },
           ),
         ],
@@ -637,7 +637,7 @@ class _LabsScreenState extends ConsumerState<LabsScreen>
         subtitle: Text(description),
         trailing: ElevatedButton(
           onPressed: () {
-            // TODO: Launch AI tool
+            Navigator.pushNamed(context, '/launch-ai-tool', arguments: {'toolName': title});
           },
           style: ElevatedButton.styleFrom(
             backgroundColor: color,
@@ -825,7 +825,7 @@ class _LabsScreenState extends ConsumerState<LabsScreen>
                 Expanded(
                   child: OutlinedButton(
                     onPressed: () {
-                      // TODO: View prototype
+                      Navigator.pushNamed(context, '/view-prototype', arguments: {'prototypeName': title});
                     },
                     child: const Text('View'),
                   ),
@@ -834,7 +834,7 @@ class _LabsScreenState extends ConsumerState<LabsScreen>
                 Expanded(
                   child: ElevatedButton(
                     onPressed: () {
-                      // TODO: Test prototype
+                      Navigator.pushNamed(context, '/test-prototype', arguments: {'prototypeName': title});
                     },
                     style: ElevatedButton.styleFrom(
                       backgroundColor: color,
@@ -1005,7 +1005,7 @@ class _LabsScreenState extends ConsumerState<LabsScreen>
               Expanded(
                 child: OutlinedButton(
                   onPressed: () {
-                    // TODO: Explore idea
+                      Navigator.pushNamed(context, '/explore-idea', arguments: {'ideaName': title});
                   },
                   child: const Text('Explore'),
                 ),
@@ -1014,7 +1014,7 @@ class _LabsScreenState extends ConsumerState<LabsScreen>
               Expanded(
                 child: ElevatedButton(
                   onPressed: () {
-                    // TODO: Start research
+                      Navigator.pushNamed(context, '/start-research', arguments: {'ideaName': title});
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: color,
@@ -1182,7 +1182,7 @@ class _LabsScreenState extends ConsumerState<LabsScreen>
           const SizedBox(height: 8),
           ElevatedButton(
             onPressed: () {
-              // TODO: Join challenge
+              Navigator.pushNamed(context, '/join-challenge', arguments: {'challengeName': description});
             },
             style: ElevatedButton.styleFrom(
               backgroundColor: color,


### PR DESCRIPTION
Replaced placeholder TODO comments and Snackbar messages with `Navigator.pushNamed` calls to enable navigation to various features from the Jams and Labs screens.

- Implemented navigation for creating jams and viewing jam details in `jams_screen.dart`.
- Implemented navigation for lab settings, help, experiments, AI tools, prototypes, ideas, and challenges in `labs_screen.dart`.
- Assumes corresponding named routes and argument handling are implemented elsewhere in the application.