### PR TITLE
Implement various TODOs in discussion and content filter screens

### DIFF
--- a/lib/src/features/a_ideation/presentation/discussion_screen.dart
+++ b/lib/src/features/a_ideation/presentation/discussion_screen.dart
@@ -1,6 +1,50 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+class _DiscussionData {
+  final String title;
+  final String author;
+  final String category;
+  final String time;
+  final int likes;
+  final int replies;
+  final int views;
+  final bool isPinned;
+  bool isLiked; // Added for like functionality
+
+  _DiscussionData({
+    required this.title,
+    required this.author,
+    required this.category,
+    required this.time,
+    required this.likes,
+    required this.replies,
+    required this.views,
+    required this.isPinned,
+    this.isLiked = false,
+  });
+}
+
+class _MyTopicData {
+  String title;
+  String category;
+  final String time; // Assuming time is fixed
+  final int replies; // Assuming replies are fixed for this scope
+  final int views;   // Assuming views are fixed for this scope
+  String status;
+  String content; // Added for editing
+
+  _MyTopicData({
+    required this.title,
+    required this.category,
+    required this.time,
+    required this.replies,
+    required this.views,
+    required this.status,
+    required this.content,
+  });
+}
+
 class DiscussionScreen extends ConsumerStatefulWidget {
   const DiscussionScreen({super.key});
 
@@ -13,6 +57,32 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
   late TabController _tabController;
   String _selectedCategory = 'All';
   String _sortBy = 'Latest';
+
+  // Search state
+  bool _isSearching = false;
+  String _searchQuery = '';
+  final FocusNode _searchFocusNode = FocusNode();
+  final TextEditingController _searchController = TextEditingController();
+
+  // Data for discussions
+  final List<_DiscussionData> _allDiscussions = [
+    _DiscussionData(title: 'What AI tools are you using for game development?', author: 'John Doe', category: 'General', time: '2 hours ago', likes: 15, replies: 8, views: 125, isPinned: true),
+    _DiscussionData(title: 'Unity vs Unreal for AI integration - which is better?', author: 'Jane Smith', category: 'Game Development', time: '4 hours ago', likes: 23, replies: 12, views: 89, isPinned: false),
+    _DiscussionData(title: 'Flutter game development tips and tricks', author: 'Bob Johnson', category: 'Flutter', time: '6 hours ago', likes: 8, replies: 5, views: 67, isPinned: false),
+    _DiscussionData(title: 'Showcase: My AI-powered adventure game', author: 'Alice Brown', category: 'Showcase', time: '1 day ago', likes: 45, replies: 18, views: 234, isPinned: true),
+    _DiscussionData(title: 'Help needed with 3D model optimization', author: 'Charlie Wilson', category: '3D Modeling', time: '1 day ago', likes: 12, replies: 6, views: 78, isPinned: false),
+    _DiscussionData(title: 'Best practices for AI NPCs in games', author: 'Diana Miller', category: 'AI & Machine Learning', time: '2 days ago', likes: 31, replies: 14, views: 156, isPinned: false),
+  ];
+
+  List<_DiscussionData> _filteredDiscussions = [];
+
+  // Data for My Topics
+  final List<_MyTopicData> _myTopics = [
+    _MyTopicData(title: 'How to integrate AI in Unity games?', category: 'General', time: '2 days ago', replies: 12, views: 5, status: 'Active', content: 'Looking for best practices and examples for AI integration in Unity. Specifically interested in behavior trees and pathfinding.'),
+    _MyTopicData(title: 'Flutter game performance optimization', category: 'Flutter', time: '1 week ago', replies: 8, views: 3, status: 'Resolved', content: 'What are the key areas to focus on for optimizing Flutter game performance? Any specific packages or techniques?'),
+    _MyTopicData(title: 'Showcase: My first AI game', category: 'Showcase', time: '2 weeks ago', replies: 25, views: 12, status: 'Active', content: 'Just finished my first game featuring simple AI enemies. Would love feedback!'),
+  ];
+  String? _editingTopicCategory; // For create/edit dialog
 
   final List<String> _categories = [
     'All',
@@ -38,33 +108,89 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 3, vsync: this);
+    _filteredDiscussions = _allDiscussions;
+    _searchController.addListener(() {
+      _filterDiscussions();
+    });
   }
 
   @override
   void dispose() {
     _tabController.dispose();
+    _searchController.dispose();
+    _searchFocusNode.dispose();
     super.dispose();
+  }
+
+  void _filterDiscussions() {
+    final query = _searchController.text.toLowerCase();
+    setState(() {
+      _searchQuery = query;
+      _filteredDiscussions = _allDiscussions.where((discussion) {
+        return discussion.title.toLowerCase().contains(query) ||
+               discussion.author.toLowerCase().contains(query) ||
+               discussion.category.toLowerCase().contains(query);
+      }).toList();
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Community Forum'),
+        title: _isSearching
+            ? TextField(
+                controller: _searchController,
+                focusNode: _searchFocusNode,
+                autofocus: true,
+                decoration: InputDecoration(
+                  hintText: 'Search discussions...',
+                  border: InputBorder.none,
+                  hintStyle: TextStyle(color: Colors.white.withAlpha(200)),
+                ),
+                style: const TextStyle(color: Colors.white),
+                onChanged: (query) {
+                  setState(() {
+                    _searchQuery = query;
+                  });
+                },
+              )
+            : const Text('Community Forum'),
         backgroundColor: Colors.green,
         foregroundColor: Colors.white,
         elevation: 0,
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.search),
-            onPressed: () {
-              // TODO: Search discussions
-            },
-          ),
-          IconButton(
+        actions: _isSearching
+            ? [
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () {
+                    setState(() {
+                      _isSearching = false;
+                      _searchQuery = '';
+                      _searchController.clear();
+                    });
+                  },
+                ),
+              ]
+            : [
+                IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: () {
+                    setState(() {
+                      _isSearching = true;
+                    });
+                    _searchFocusNode.requestFocus();
+                  },
+                ),
+                IconButton(
             icon: const Icon(Icons.notifications),
             onPressed: () {
-              // TODO: Show notifications
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Notifications feature coming soon!'),
+                  duration: Duration(seconds: 2),
+                ),
+              );
             },
           ),
         ],
@@ -88,85 +214,93 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
           _buildMyTopicsTab(),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          _showCreateTopicDialog();
-        },
-        backgroundColor: Colors.green,
-        child: const Icon(Icons.add, color: Colors.white),
-      ),
+      floatingActionButton: _isSearching
+          ? null
+          : FloatingActionButton(
+              onPressed: () {
+                _showCreateTopicDialog();
+              },
+              backgroundColor: Colors.green,
+              child: const Icon(Icons.add, color: Colors.white),
+            ),
     );
   }
 
   Widget _buildDiscussionsTab() {
+    // Apply category filter first
+    List<_DiscussionData> discussionsToDisplay = _selectedCategory == 'All'
+        ? _filteredDiscussions
+        : _filteredDiscussions
+            .where((d) => d.category == _selectedCategory)
+            .toList();
+
+    // Then apply sorting (basic example, can be expanded)
+    if (_sortBy == 'Most Popular') {
+      discussionsToDisplay.sort((a, b) => b.views.compareTo(a.views));
+    } else if (_sortBy == 'Most Replies') {
+      discussionsToDisplay.sort((a, b) => b.replies.compareTo(a.replies));
+    } else { // Default to Latest (assuming current order is somewhat latest)
+      // For a true 'Latest' sort, you'd need a timestamp.
+      // For now, pinned items go first.
+      discussionsToDisplay.sort((a, b) {
+        if (a.isPinned && !b.isPinned) return -1;
+        if (!a.isPinned && b.isPinned) return 1;
+        // Add time-based sorting here if available
+        return 0;
+      });
+    }
+
+    if (discussionsToDisplay.isEmpty && _searchQuery.isNotEmpty) {
+      return Center(
+        child: Text(
+          'No discussions found for "$_searchQuery".',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+      );
+    }
+
+    if (discussionsToDisplay.isEmpty && _selectedCategory != 'All') {
+       return Center(
+        child: Text(
+          'No discussions in $_selectedCategory yet.',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+      );
+    }
+
+
     return Column(
       children: [
         _buildFilterBar(),
         Expanded(
-          child: ListView(
+          child: ListView.builder(
             padding: const EdgeInsets.all(16),
-            children: [
-              _buildDiscussionCard(
-                'What AI tools are you using for game development?',
-                'John Doe',
-                'General',
-                '2 hours ago',
-                15,
-                8,
-                125,
-                true,
-              ),
-              _buildDiscussionCard(
-                'Unity vs Unreal for AI integration - which is better?',
-                'Jane Smith',
-                'Game Development',
-                '4 hours ago',
-                23,
-                12,
-                89,
-                false,
-              ),
-              _buildDiscussionCard(
-                'Flutter game development tips and tricks',
-                'Bob Johnson',
-                'Flutter',
-                '6 hours ago',
-                8,
-                5,
-                67,
-                false,
-              ),
-              _buildDiscussionCard(
-                'Showcase: My AI-powered adventure game',
-                'Alice Brown',
-                'Showcase',
-                '1 day ago',
-                45,
-                18,
-                234,
-                true,
-              ),
-              _buildDiscussionCard(
-                'Help needed with 3D model optimization',
-                'Charlie Wilson',
-                '3D Modeling',
-                '1 day ago',
-                12,
-                6,
-                78,
-                false,
-              ),
-              _buildDiscussionCard(
-                'Best practices for AI NPCs in games',
-                'Diana Miller',
-                'AI & Machine Learning',
-                '2 days ago',
-                31,
-                14,
-                156,
-                false,
-              ),
-            ],
+            itemCount: discussionsToDisplay.length,
+            itemBuilder: (context, index) {
+              final discussion = discussionsToDisplay[index];
+              return _buildDiscussionCard(
+                discussion.title,
+                discussion.author,
+                discussion.category,
+                discussion.time,
+                discussion.likes,
+                discussion.replies,
+                discussion.views,
+                discussion.isPinned,
+                discussion.isLiked, // Pass liked state
+                () { // Callback for liking
+                  setState(() {
+                    discussion.isLiked = !discussion.isLiked;
+                    if (discussion.isLiked) {
+                      // In a real app, you might increment a counter if not already liked
+                      // discussion.likes++;
+                    } else {
+                      // discussion.likes--;
+                    }
+                  });
+                }
+              );
+            },
           ),
         ),
       ],
@@ -237,7 +371,40 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
     );
   }
 
-  Widget _buildDiscussionCard(String title, String author, String category, String time, int likes, int replies, int views, bool isPinned) {
+  void _showDeleteTopicConfirmationDialog(_MyTopicData topic) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Topic'),
+        content: Text('Are you sure you want to delete the topic "${topic.title}"? This action cannot be undone.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            onPressed: () {
+              setState(() {
+                _myTopics.remove(topic);
+              });
+              Navigator.pop(context);
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Topic "${topic.title}" deleted.')),
+              );
+            },
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDiscussionCard(String title, String author, String category, String time, int likes, int replies, int views, bool isPinned, bool isLiked, VoidCallback onLikePressed) {
+    // The 'likes' count will come directly from the discussion data.
+    // The 'isLiked' state will control the icon.
+    // Actual increment/decrement of 'likes' would be a backend operation.
+
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
       elevation: 2,
@@ -269,13 +436,13 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                   decoration: BoxDecoration(
-                    color: _getCategoryColor(category).withAlpha(25),
+                    color: _getCategoryColor(topic.category).withAlpha(25),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Text(
-                    category,
+                    topic.category,
                     style: TextStyle(
-                      color: _getCategoryColor(category),
+                      color: _getCategoryColor(topic.category),
                       fontWeight: FontWeight.bold,
                       fontSize: 12,
                     ),
@@ -328,17 +495,24 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
             Row(
               children: [
                 IconButton(
-                  icon: const Icon(Icons.thumb_up_outlined, size: 20),
-                  onPressed: () {
-                    // TODO: Like discussion
-                  },
+                  icon: Icon(
+                    isLiked ? Icons.thumb_up : Icons.thumb_up_outlined,
+                    size: 20,
+                    color: isLiked ? Colors.green : null,
+                  ),
+                  onPressed: onLikePressed,
                 ),
-                Text('$likes'),
+                Text('$likes'), // Now using likes directly
                 const SizedBox(width: 16),
                 IconButton(
                   icon: const Icon(Icons.reply, size: 20),
                   onPressed: () {
-                    // TODO: Reply to discussion
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Reply feature coming soon!'),
+                        duration: Duration(seconds: 2),
+                      ),
+                    );
                   },
                 ),
                 Text('$replies'),
@@ -353,11 +527,30 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
                   ),
                 ),
                 const Spacer(),
-                IconButton(
+                PopupMenuButton<String>(
                   icon: const Icon(Icons.more_vert, size: 20),
-                  onPressed: () {
-                    // TODO: Show options
+                  onSelected: (value) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('$value option selected. Coming soon!'),
+                        duration: const Duration(seconds: 2),
+                      ),
+                    );
                   },
+                  itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+                    const PopupMenuItem<String>(
+                      value: 'Edit',
+                      child: Text('Edit Discussion'),
+                    ),
+                    const PopupMenuItem<String>(
+                      value: 'Delete',
+                      child: Text('Delete Discussion'),
+                    ),
+                    const PopupMenuItem<String>(
+                      value: 'Report',
+                      child: Text('Report Discussion'),
+                    ),
+                  ],
                 ),
               ],
             ),
@@ -444,7 +637,10 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
         ),
         trailing: const Icon(Icons.arrow_forward_ios),
         onTap: () {
-          // TODO: Navigate to category
+          setState(() {
+            _selectedCategory = name; // 'name' is the category name from _buildCategoryCard
+            _tabController.animateTo(0); // Animate to the Discussions tab (index 0)
+          });
         },
       ),
     );
@@ -476,38 +672,25 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
   }
 
   Widget _buildMyTopicsTab() {
-    return ListView(
+    if (_myTopics.isEmpty) {
+      return const Center(
+        child: Text(
+          'You have not created any topics yet.',
+          style: TextStyle(fontSize: 16, color: Colors.grey),
+        ),
+      );
+    }
+    return ListView.builder(
       padding: const EdgeInsets.all(16),
-      children: [
-        _buildMyTopicCard(
-          'How to integrate AI in Unity games?',
-          'General',
-          '2 days ago',
-          12,
-          5,
-          'Active',
-        ),
-        _buildMyTopicCard(
-          'Flutter game performance optimization',
-          'Flutter',
-          '1 week ago',
-          8,
-          3,
-          'Resolved',
-        ),
-        _buildMyTopicCard(
-          'Showcase: My first AI game',
-          'Showcase',
-          '2 weeks ago',
-          25,
-          12,
-          'Active',
-        ),
-      ],
+      itemCount: _myTopics.length,
+      itemBuilder: (context, index) {
+        final topic = _myTopics[index];
+        return _buildMyTopicCard(topic);
+      },
     );
   }
 
-  Widget _buildMyTopicCard(String title, String category, String time, int replies, int views, String status) {
+  Widget _buildMyTopicCard(_MyTopicData topic) {
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
       elevation: 2,
@@ -538,13 +721,13 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                   decoration: BoxDecoration(
-                    color: status == 'Active' ? Colors.green.withAlpha(25) : Colors.grey.withAlpha(25),
+                    color: topic.status == 'Active' ? Colors.green.withAlpha(25) : Colors.grey.withAlpha(25),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Text(
-                    status,
+                    topic.status,
                     style: TextStyle(
-                      color: status == 'Active' ? Colors.green : Colors.grey,
+                      color: topic.status == 'Active' ? Colors.green : Colors.grey,
                       fontWeight: FontWeight.bold,
                       fontSize: 12,
                     ),
@@ -554,7 +737,7 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
             ),
             const SizedBox(height: 12),
             Text(
-              title,
+              topic.title,
               style: const TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.bold,
@@ -564,7 +747,7 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
             Row(
               children: [
                 Text(
-                  time,
+                  topic.time,
                   style: TextStyle(
                     color: Colors.grey[600],
                     fontSize: 12,
@@ -574,7 +757,7 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
                 Icon(Icons.reply, size: 16, color: Colors.grey[600]),
                 const SizedBox(width: 4),
                 Text(
-                  '$replies replies',
+                  '${topic.replies} replies',
                   style: TextStyle(
                     color: Colors.grey[600],
                     fontSize: 12,
@@ -584,7 +767,7 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
                 Icon(Icons.visibility, size: 16, color: Colors.grey[600]),
                 const SizedBox(width: 4),
                 Text(
-                  '$views views',
+                  '${topic.views} views',
                   style: TextStyle(
                     color: Colors.grey[600],
                     fontSize: 12,
@@ -600,7 +783,7 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
                     icon: const Icon(Icons.edit),
                     label: const Text('Edit'),
                     onPressed: () {
-                      // TODO: Edit topic
+                      _showEditTopicDialog(topic);
                     },
                   ),
                 ),
@@ -610,7 +793,7 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
                     icon: const Icon(Icons.delete),
                     label: const Text('Delete'),
                     onPressed: () {
-                      // TODO: Delete topic
+                      _showDeleteTopicConfirmationDialog(topic);
                     },
                   ),
                 ),
@@ -623,45 +806,70 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
   }
 
   void _showCreateTopicDialog() {
+    final formKey = GlobalKey<FormState>(); // For validation
+    final titleController = TextEditingController();
+    final contentController = TextEditingController();
+    // Ensure _editingTopicCategory is initialized for the create dialog
+    // Default to the first actual category, or null if no categories exist (besides 'All')
+    _editingTopicCategory = _categories.length > 1 ? _categories[1] : null;
+
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Create New Topic'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            DropdownButtonFormField<String>(
-              decoration: const InputDecoration(
-                labelText: 'Category',
-                border: OutlineInputBorder(),
-              ),
-              items: _categories.skip(1).map((category) {
-                return DropdownMenuItem(
-                  value: category,
-                  child: Text(category),
-                );
-              }).toList(),
-              onChanged: (value) {
-                // TODO: Handle category selection
-              },
-            ),
-            const SizedBox(height: 16),
-            TextFormField(
-              decoration: const InputDecoration(
-                labelText: 'Title',
-                border: OutlineInputBorder(),
-              ),
-            ),
-            const SizedBox(height: 16),
-            TextFormField(
-              maxLines: 4,
-              decoration: const InputDecoration(
-                labelText: 'Content',
-                border: OutlineInputBorder(),
-                alignLabelWithHint: true,
-              ),
-            ),
-          ],
+        content: Form( // Wrap content in a Form
+          key: formKey,
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setStateDialog) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  DropdownButtonFormField<String>(
+                    decoration: const InputDecoration(
+                      labelText: 'Category',
+                      border: OutlineInputBorder(),
+                    ),
+                    value: _editingTopicCategory,
+                    items: _categories.skip(1).map((category) {
+                      return DropdownMenuItem(
+                        value: category,
+                        child: Text(category),
+                      );
+                    }).toList(),
+                    onChanged: (value) {
+                      if (value != null) {
+                        setStateDialog(() {
+                          _editingTopicCategory = value;
+                        });
+                      }
+                    },
+                    validator: (value) => value == null ? 'Please select a category' : null,
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: titleController,
+                    decoration: const InputDecoration(
+                      labelText: 'Title',
+                      border: OutlineInputBorder(),
+                    ),
+                    validator: (value) => value == null || value.isEmpty ? 'Please enter a title' : null,
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: contentController,
+                    maxLines: 4,
+                    decoration: const InputDecoration(
+                      labelText: 'Content',
+                      border: OutlineInputBorder(),
+                      alignLabelWithHint: true,
+                    ),
+                    validator: (value) => value == null || value.isEmpty ? 'Please enter content' : null,
+                  ),
+                ],
+              );
+            }
+          ),
         ),
         actions: [
           TextButton(
@@ -672,10 +880,114 @@ class _DiscussionScreenState extends ConsumerState<DiscussionScreen>
           ),
           ElevatedButton(
             onPressed: () {
-              // TODO: Create topic
-              Navigator.pop(context);
+              if (formKey.currentState!.validate()) {
+                if (_editingTopicCategory == null) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Please select a category first.')),
+                  );
+                  return;
+                }
+                final newTopic = _MyTopicData(
+                  title: titleController.text,
+                  category: _editingTopicCategory!,
+                  time: 'Just now',
+                  replies: 0,
+                  views: 0,
+                  status: 'Active',
+                  content: contentController.text,
+                );
+                setState(() {
+                  _myTopics.insert(0, newTopic);
+                });
+                Navigator.pop(context);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('Topic "${newTopic.title}" created!')),
+                );
+              }
             },
             child: const Text('Create'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showEditTopicDialog(_MyTopicData topic) {
+    _editingTopicCategory = topic.category;
+    final titleController = TextEditingController(text: topic.title);
+    final contentController = TextEditingController(text: topic.content);
+
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Edit Topic'),
+        content: StatefulBuilder( // Use StatefulBuilder to update dialog state for dropdown
+          builder: (BuildContext context, StateSetter setStateDialog) {
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                DropdownButtonFormField<String>(
+                  decoration: const InputDecoration(
+                    labelText: 'Category',
+                    border: OutlineInputBorder(),
+                  ),
+                  value: _editingTopicCategory,
+                  items: _categories.skip(1).map((category) { // Skip 'All'
+                    return DropdownMenuItem(
+                      value: category,
+                      child: Text(category),
+                    );
+                  }).toList(),
+                  onChanged: (value) {
+                    if (value != null) {
+                      setStateDialog(() { // Use setState from StatefulBuilder
+                        _editingTopicCategory = value;
+                      });
+                    }
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: titleController,
+                  decoration: const InputDecoration(
+                    labelText: 'Title',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: contentController,
+                  maxLines: 4,
+                  decoration: const InputDecoration(
+                    labelText: 'Content',
+                    border: OutlineInputBorder(),
+                    alignLabelWithHint: true,
+                  ),
+                ),
+              ],
+            );
+          }
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+            },
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              setState(() {
+                topic.title = titleController.text;
+                topic.content = contentController.text;
+                topic.category = _editingTopicCategory ?? topic.category; // Fallback if null
+              });
+              Navigator.pop(context);
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Topic updated locally! (Not saved permanently)')),
+              );
+            },
+            child: const Text('Save Changes'),
           ),
         ],
       ),

--- a/lib/src/features/a_ideation/presentation/enhanced_content_filter_screen.dart
+++ b/lib/src/features/a_ideation/presentation/enhanced_content_filter_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-// TODO: Implement or restore enhanced_chip.dart
-// import 'package:project_jambam/src/shared/enhanced_chip.dart';
+import 'package:project_jambam/src/shared/enhanced_chip.dart';
 import '../data/content_filter_service.dart';
 import '../domain/content_filter_system.dart';
 


### PR DESCRIPTION
This commit addresses multiple TODO items in the ideation feature:

- Enhanced Content Filter Screen:
  - Restored the import for `enhanced_chip.dart`.

- Discussion Screen:
  - Implemented inline search functionality for discussions.
  - Added placeholder SnackBar for notifications.
  - Implemented UI for liking/unliking discussions (local state).
  - Added placeholder SnackBar for replying to discussions.
  - Added placeholder PopupMenu for discussion options (Edit, Delete, Report).
  - Implemented navigation to specific categories from the categories tab.
  - Implemented editing of user's own topics (local state).
  - Implemented deletion of user's own topics with confirmation (local state).
  - Handled category selection within the create/edit topic dialogs.
  - Implemented creation of new topics with form validation (local state).

All functionalities involving data persistence are currently local to the screen state.