### PR TITLE
Refactor: Swap skill chip styles for favorite and non-favorite items

### DIFF
--- a/web-portal/bjarne-portfolio-next/src/components/Skills.tsx
+++ b/web-portal/bjarne-portfolio-next/src/components/Skills.tsx
@@ -194,15 +194,18 @@ const Skills: React.FC = () => {
                         {isTop && <StarIcon sx={{ fontSize: 18, color: 'gold', ml: 0.5 }} />}
                       </Box>
                     }
-                    color={isTop ? 'primary' : undefined}
-                    variant={isTop ? 'filled' : 'outlined'}
+                    // Swapped styles:
+                    color={isTop ? undefined : 'primary'}
+                    variant={isTop ? 'outlined' : 'filled'}
                     sx={{
                       fontSize: '1rem',
                       fontWeight: 500,
                       p: 2,
                       cursor: 'pointer',
-                      borderColor: 'primary.main',
-                      background: 'rgba(179,157,219,0.07)',
+                      // Apply specific styles to isTop (formerly non-favorite)
+                      borderColor: isTop ? 'primary.main' : undefined,
+                      background: isTop ? 'rgba(179,157,219,0.07)' : undefined,
+                      // Non-isTop (formerly favorite) will get its background from 'primary' color & 'filled' variant
                       transition: 'all 0.2s',
                       '&:hover': {
                         transform: 'scale(1.05)',


### PR DESCRIPTION
Swaps the visual styling (color, variant, background, border) between favorite and non-favorite skills in the portfolio's skills section.

- Favorite skills (marked with a star) now use the outlined style previously used by non-favorite skills.
- Non-favorite skills now use the primary-colored filled style previously used by favorite skills.

The star icon indicator for favorite skills and the hover effects for all skill chips remain unchanged.

## 📋 Pull Request Description
<!-- Brief description of what this PR implements or fixes -->

## 🎯 Related Issue
<!-- Link to the related issue -->
Closes #(issue number)

## 🔧 Changes Made
<!-- List of specific changes implemented -->

### New Features
- [ ] Feature 1
- [ ] Feature 2

### Bug Fixes
- [ ] Fix 1
- [ ] Fix 2

### Improvements
- [ ] Improvement 1
- [ ] Improvement 2

### Breaking Changes
- [ ] Breaking change 1 (if any)
- [ ] Breaking change 2 (if any)

## 🧪 Testing
<!-- Describe the testing that was performed -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] UI tests added/updated
- [ ] Manual testing performed

### Test Scenarios
- [ ] Scenario 1
- [ ] Scenario 2
- [ ] Edge cases tested

## 📱 Platform Testing
<!-- Which platforms were tested -->
- [ ] Windows Desktop
- [ ] macOS Desktop
- [ ] Linux Desktop
- [ ] Web (Chrome)
- [ ] Web (Firefox)
- [ ] Web (Safari)
- [ ] Web (Edge)
- [ ] Android
- [ ] iOS

## 🔒 Security Considerations
<!-- Any security aspects that were addressed -->
- [ ] Input validation implemented
- [ ] Authentication flow tested
- [ ] Authorization checks added
- [ ] Data encryption verified
- [ ] Security scan passed

## 📝 Documentation
<!-- Documentation updates -->
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] README updated
- [ ] User documentation updated

## 🎨 UI/UX Changes
<!-- Any UI/UX changes made -->
- [ ] UI components updated
- [ ] Responsive design verified
- [ ] Accessibility improvements
- [ ] User experience enhanced

## ⚡ Performance Impact
<!-- Performance considerations -->
- [ ] Performance tested
- [ ] No performance regression
- [ ] Optimizations implemented
- [ ] Bundle size impact assessed

## 🔄 Migration/Deployment
<!-- Any migration or deployment considerations -->
- [ ] Database migrations (if any)
- [ ] Environment variables updated
- [ ] Deployment steps documented
- [ ] Rollback plan prepared

## 📊 Metrics & Monitoring
<!-- Any metrics or monitoring added -->
- [ ] Analytics events added
- [ ] Error tracking implemented
- [ ] Performance monitoring added
- [ ] User behavior tracking

## 🚀 Checklist

### Before Review
- [ ] Code follows project standards
- [ ] All tests are passing
- [ ] No linting errors
- [ ] Documentation is complete
- [ ] Security review completed
- [ ] Performance impact assessed

### Before Merging
- [ ] Code review approved
- [ ] All CI/CD checks passing
- [ ] Security scan clean
- [ ] Performance benchmarks met
- [ ] Documentation reviewed
- [ ] Stakeholder approval (if required)

## 📸 Screenshots/Videos
<!-- Add screenshots or videos if UI changes were made -->
<!-- Drag and drop images here or paste URLs -->

## 🔗 Additional Resources
<!-- Any additional resources, links, or context -->
- Design files:
- API documentation:
- Related PRs:
- External resources:

## 📋 Reviewer Notes
<!-- Any specific notes for reviewers -->
<!-- What should reviewers pay special attention to -->

## 🎯 Definition of Done
<!-- Confirm that all acceptance criteria are met -->
- [ ] All acceptance criteria from the issue are met
- [ ] Code is production-ready
- [ ] No known issues remain
- [ ] Stakeholder approval received (if applicable)

---

## 📊 PR Metrics
<!-- Optional: Track PR metrics for process improvement -->
- **Lines of code**: 
- **Files changed**: 
- **Time to review**: 
- **Review iterations**: 
- **Test coverage**: 